### PR TITLE
clangd: use smallest matching symbol as definition result

### DIFF
--- a/integrationtests/snapshots/clangd/definition/method.snap
+++ b/integrationtests/snapshots/clangd/definition/method.snap
@@ -4,15 +4,7 @@ Symbol: method
 /TEST_OUTPUT/workspace/clangd/src/consumer.cpp
 Kind: Method
 Container Name: TestClass
-Range: L7:C1 - L15:C2
+Range: L14:C1 - L14:C47
 
- 7|class TestClass {
- 8| public:
- 9|  /**
-10|   * @brief A method that takes an integer parameter.
-11|   *
-12|   * @param param The integer parameter to be processed.
-13|   */
 14|  void method(int param) { helperFunction(); }
-15|};
 

--- a/integrationtests/snapshots/clangd/definition/nsFunction.snap
+++ b/integrationtests/snapshots/clangd/definition/nsFunction.snap
@@ -1,0 +1,12 @@
+---
+
+Symbol: nsFunction2
+/TEST_OUTPUT/workspace/clangd/src/namespace.cpp
+Kind: Function
+Container Name: ns
+Range: L11:C1 - L13:C2
+
+11|void nsFunction2() {
+12|    // empty   
+13|}
+

--- a/integrationtests/snapshots/python/definition/method.snap
+++ b/integrationtests/snapshots/python/definition/method.snap
@@ -4,21 +4,8 @@ Symbol: test_method
 /TEST_OUTPUT/workspace/main.py
 Kind: Method
 Container Name: TestClass
-Range: L18:C1 - L59:C22
+Range: L31:C1 - L41:C26
 
-18|class TestClass:
-19|    """A test class with methods and attributes."""
-20|
-21|    class_variable: str = "class variable"
-22|
-23|    def __init__(self, value: int = 0):
-24|        """Initialize the TestClass.
-25|
-26|        Args:
-27|            value: The initial value
-28|        """
-29|        self.value: int = value
-30|
 31|    def test_method(self, increment: int) -> int:
 32|        """Increment the value by the given amount.
 33|
@@ -30,22 +17,4 @@ Range: L18:C1 - L59:C22
 39|        """
 40|        self.value += increment
 41|        return self.value
-42|
-43|    @staticmethod
-44|    def static_method(items: list[str]) -> dict[str, int]:
-45|        """Convert a list of items to a dictionary with item counts.
-46|
-47|        Args:
-48|            items: A list of strings
-49|
-50|        Returns:
-51|            A dictionary mapping items to their counts
-52|        """
-53|        result: dict[str, int] = {}
-54|        for item in items:
-55|            if item in result:
-56|                result[item] += 1
-57|            else:
-58|                result[item] = 1
-59|        return result
 

--- a/integrationtests/snapshots/python/definition/static-method.snap
+++ b/integrationtests/snapshots/python/definition/static-method.snap
@@ -4,33 +4,8 @@ Symbol: static_method
 /TEST_OUTPUT/workspace/main.py
 Kind: Method
 Container Name: TestClass
-Range: L18:C1 - L59:C22
+Range: L43:C1 - L59:C22
 
-18|class TestClass:
-19|    """A test class with methods and attributes."""
-20|
-21|    class_variable: str = "class variable"
-22|
-23|    def __init__(self, value: int = 0):
-24|        """Initialize the TestClass.
-25|
-26|        Args:
-27|            value: The initial value
-28|        """
-29|        self.value: int = value
-30|
-31|    def test_method(self, increment: int) -> int:
-32|        """Increment the value by the given amount.
-33|
-34|        Args:
-35|            increment: The amount to increment by
-36|
-37|        Returns:
-38|            The new value
-39|        """
-40|        self.value += increment
-41|        return self.value
-42|
 43|    @staticmethod
 44|    def static_method(items: list[str]) -> dict[str, int]:
 45|        """Convert a list of items to a dictionary with item counts.

--- a/integrationtests/snapshots/rust/definition/method.snap
+++ b/integrationtests/snapshots/rust/definition/method.snap
@@ -4,21 +4,11 @@ Symbol: method
 /TEST_OUTPUT/workspace/src/types.rs
 Kind: Function
 Container Name: TestStruct
-Range: L18:C1 - L30:C2
+Range: L27:C1 - L29:C6
 
-18|// Implementation for TestStruct
-19|impl TestStruct {
-20|    pub fn new(name: &str, value: i32) -> Self {
-21|        TestStruct {
-22|            name: String::from(name),
-23|            value,
-24|        }
-25|    }
-26|
 27|    pub fn method(&self) -> String {
 28|        format!("{}: {}", self.name, self.value)
 29|    }
-30|}
 
 ---
 
@@ -26,17 +16,9 @@ Symbol: method
 /TEST_OUTPUT/workspace/src/types.rs
 Kind: Function
 Container Name: SharedStruct
-Range: L54:C1 - L64:C2
+Range: L61:C1 - L63:C6
 
-54|impl SharedStruct {
-55|    pub fn new(name: &str) -> Self {
-56|        SharedStruct {
-57|            name: String::from(name),
-58|        }
-59|    }
-60|
 61|    pub fn method(&self) -> String {
 62|        format!("SharedStruct: {}", self.name)
 63|    }
-64|}
 

--- a/integrationtests/tests/clangd/definition/definition_test.go
+++ b/integrationtests/tests/clangd/definition/definition_test.go
@@ -66,6 +66,12 @@ func TestReadDefinition(t *testing.T) {
 			snapshotName: "method",
 		},
 		{
+			name:         "Namespace function",
+			symbolName:   "nsFunction2",
+			expectedText: "void nsFunction2()",
+			snapshotName: "nsFunction",
+		},
+		{
 			name:         "Struct",
 			symbolName:   "TestStruct",
 			expectedText: "struct TestStruct",

--- a/integrationtests/workspaces/clangd/Makefile
+++ b/integrationtests/workspaces/clangd/Makefile
@@ -29,7 +29,7 @@ TARGET_CLEAN_PROGRAM = clean_program # Assuming this is another program to be bu
 # Listing them explicitly for clarity in target dependencies.
 OBJ_MAIN = $(OBJDIR)/main.o
 # Add other specific object files your 'program' executable depends on
-OTHER_OBJS = $(OBJDIR)/helper.o $(OBJDIR)/types.o $(OBJDIR)/consumer.o $(OBJDIR)/another_consumer.o
+OTHER_OBJS = $(OBJDIR)/helper.o $(OBJDIR)/types.o $(OBJDIR)/consumer.o $(OBJDIR)/another_consumer.o $(OBJDIR)/namespace.o
 OBJ_FOR_CLEAN_PROGRAM = $(OBJDIR)/clean.o
 
 

--- a/integrationtests/workspaces/clangd/src/namespace.cpp
+++ b/integrationtests/workspaces/clangd/src/namespace.cpp
@@ -1,0 +1,15 @@
+//
+// A file with a namespace in it
+//
+
+namespace ns {
+
+void nsFunction1() {
+    // empty   
+}
+
+void nsFunction2() {
+    // empty   
+}
+
+}


### PR DESCRIPTION
- Current implementation takes the first symbol. That could be a namespace, and isn't usually what you want